### PR TITLE
Removed deprecated replacement code

### DIFF
--- a/createReleaseAggregatorFile.ant
+++ b/createReleaseAggregatorFile.ant
@@ -6,10 +6,6 @@
 			match="https://sdqweb.ipd.kit.edu/eclipse/(.*)/nightly" 
 			replace="https://sdqweb.ipd.kit.edu/eclipse/\1/releases/latest" 
 			byline="true" />
-		<replaceregexp file="palladiosimulator_release.aggr" 
-			match="http://ftp-stud.hs-esslingen.de/pub/Mirrors/eclipse/" 
-			replace="http://download.eclipse.org/" 
-			byline="true" />
 	</target>
 
 </project>


### PR DESCRIPTION
We used to refer to a mirror update site in our aggregation file. We, however, do not do this anymore because we fixed reliability issues of the eclipse update sites with a HTTP proxy on the build server.

The ant file for transforming the nightly to the release aggregation file still contains code for this replacement. This code has no effect anymore and should be removed.