### PR TITLE
PALLADIO-436 Added workarounds repository.

### DIFF
--- a/palladiosimulator.aggr
+++ b/palladiosimulator.aggr
@@ -99,6 +99,7 @@
         <features name="org.palladiosimulator.license.epl2.feature.group"/>
         <features name="org.palladiosimulator.branding.feature.feature.group"/>
       </repositories>
+      <repositories location="https://sdqweb.ipd.kit.edu/eclipse/palladio/supporting/workarounds/nightly/"/>
     </contributions>
     <contributions label="Luna Platform">
       <repositories location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/">
@@ -274,6 +275,7 @@
         <features name="org.palladiosimulator.license.epl2.feature.group"/>
         <features name="org.palladiosimulator.branding.feature.feature.group"/>
       </repositories>
+      <repositories location="https://sdqweb.ipd.kit.edu/eclipse/palladio/supporting/workarounds/nightly/"/>
     </contributions>
     <contributions label="Luna Platform">
       <repositories location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/">

--- a/palladiosimulator_release.aggr
+++ b/palladiosimulator_release.aggr
@@ -99,6 +99,7 @@
         <features name="org.palladiosimulator.license.epl2.feature.group"/>
         <features name="org.palladiosimulator.branding.feature.feature.group"/>
       </repositories>
+      <repositories location="https://sdqweb.ipd.kit.edu/eclipse/palladio/supporting/workarounds/releases/latest/"/>
     </contributions>
     <contributions label="Luna Platform">
       <repositories location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/">
@@ -274,6 +275,7 @@
         <features name="org.palladiosimulator.license.epl2.feature.group"/>
         <features name="org.palladiosimulator.branding.feature.feature.group"/>
       </repositories>
+      <repositories location="https://sdqweb.ipd.kit.edu/eclipse/palladio/supporting/workarounds/releases/latest/"/>
     </contributions>
     <contributions label="Luna Platform">
       <repositories location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/">


### PR DESCRIPTION
This PR includes the workarounds repository to the aggregated update site.

This PR should be merged after PalladioSimulator/Palladio-Supporting-Workarounds#3.