### PR TITLE
Remove nebula widgets from user's view of categories

### DIFF
--- a/palladiosimulator.aggr
+++ b/palladiosimulator.aggr
@@ -166,7 +166,9 @@
       </repositories>
     </contributions>
     <contributions label="Nebula Incubation Widgets">
-      <repositories location="http://archive.eclipse.org/nebula/Q22016/incubation/" mirrorArtifacts="false"/>
+      <repositories location="http://archive.eclipse.org/nebula/Q22016/incubation/" mirrorArtifacts="false">
+        <features name="org.eclipse.nebula.incubation.feature.feature.group"/>
+      </repositories>
     </contributions>
     <validationRepositories location="http://download.eclipse.org/eclipse/updates/4.12/"/>
     <validationRepositories location="http://download.eclipse.org/releases/2019-06"/>

--- a/palladiosimulator_release.aggr
+++ b/palladiosimulator_release.aggr
@@ -156,13 +156,18 @@
       <repositories location="http://download.eclipse.org/modeling/emft/henshin/updates/release" mirrorArtifacts="false">
         <features name="org.eclipse.emf.henshin.sdk.feature.group"/>
       </repositories>
-      <repositories location="http://download.eclipse.org/releases/neon/" mirrorArtifacts="false">
+      <repositories location="http://download.eclipse.org/modeling/gmp/gmf-tooling/updates/releases-3.3.1a/" mirrorArtifacts="false">
         <features name="org.eclipse.gmf.tooling.runtime.feature.group"/>
       </repositories>
     </contributions>
     <contributions label="Sirius">
       <repositories location="http://download.eclipse.org/sirius/updates/releases/6.2.2/2019-06" mirrorArtifacts="false">
         <features name="org.eclipse.sirius.runtime.feature.group"/>
+      </repositories>
+    </contributions>
+    <contributions label="Nebula Incubation Widgets">
+      <repositories location="http://archive.eclipse.org/nebula/Q22016/incubation/" mirrorArtifacts="false">
+        <features name="org.eclipse.nebula.incubation.feature.feature.group"/>
       </repositories>
     </contributions>
     <validationRepositories location="http://download.eclipse.org/eclipse/updates/4.12/"/>


### PR DESCRIPTION
At the moment, nebula widgets are shown in the user's view of categories when installing Palladio via updatesite. We should remove them.

By selecting a feature and not mapping it to a category, the whole updatesite and the feature becomes invisible.