### PR TITLE
Use correct environment variable to detect release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 			<id>nightly-build</id>
 			<activation>
 				<property>
-					<name>env.DO_RELEASE_BUILD</name>
+					<name>env.RELEASE</name>
 					<value>!true</value>
 				</property>
 			</activation>
@@ -46,7 +46,7 @@
 			<id>release-build</id>
 			<activation>
 				<property>
-					<name>env.DO_RELEASE_BUILD</name>
+					<name>env.RELEASE</name>
 					<value>true</value>
 				</property>
 			</activation>


### PR DESCRIPTION
The name of the environment variable has changed. Therefore, we have to refer to it.