### PR TITLE
Use fixed version of henshin dependency.

### DIFF
--- a/palladiosimulator.aggr
+++ b/palladiosimulator.aggr
@@ -160,7 +160,7 @@
       </repositories>
     </contributions>
     <contributions description="Henshin" label="Henshin">
-      <repositories location="http://download.eclipse.org/modeling/emft/henshin/updates/release" mirrorArtifacts="false">
+      <repositories location="http://download.eclipse.org/modeling/emft/henshin/updates/1.6.0" mirrorArtifacts="false">
         <features name="org.eclipse.emf.henshin.sdk.feature.group"/>
       </repositories>
       <repositories location="http://download.eclipse.org/modeling/gmp/gmf-tooling/updates/releases-3.3.1a/" mirrorArtifacts="false">

--- a/palladiosimulator_release.aggr
+++ b/palladiosimulator_release.aggr
@@ -160,7 +160,7 @@
       </repositories>
     </contributions>
     <contributions description="Henshin" label="Henshin">
-      <repositories location="http://download.eclipse.org/modeling/emft/henshin/updates/release" mirrorArtifacts="false">
+      <repositories location="http://download.eclipse.org/modeling/emft/henshin/updates/1.6.0" mirrorArtifacts="false">
         <features name="org.eclipse.emf.henshin.sdk.feature.group"/>
       </repositories>
       <repositories location="http://download.eclipse.org/modeling/gmp/gmf-tooling/updates/releases-3.3.1a/" mirrorArtifacts="false">


### PR DESCRIPTION
We should always stick to predictable versions. This avoid breaking builds without changes from our sides.

This PR should be merged after PalladioSimulator/Palladio-Addons-Indirections#16 and  PalladioSimulator/Palladio-Analyzer-SimuLizar#19