### PR TITLE
PALLADIO-480 Remove workarounds feature.

### DIFF
--- a/palladiosimulator.aggr
+++ b/palladiosimulator.aggr
@@ -111,7 +111,6 @@
         <features name="org.palladiosimulator.license.epl2.feature.group"/>
         <features name="org.palladiosimulator.branding.feature.feature.group"/>
       </repositories>
-      <repositories location="https://updatesite.palladio-simulator.com/palladio-supporting-workarounds/nightly/"/>
       <repositories location="https://updatesite.palladio-simulator.com/palladio-example-models-package/nightly/">
         <features name="org.palladiosimulator.examples.package.feature.feature.group"/>
       </repositories>


### PR DESCRIPTION
The workarounds feature is not required anymore. Therefore, it is removed.

PalladioSimulator/Palladio-Bench-Product#12 has to be merged before this PR.